### PR TITLE
get pid only once

### DIFF
--- a/id.go
+++ b/id.go
@@ -78,6 +78,8 @@ var objectIDCounter = randInt()
 // to NewObjectId function.
 var machineID = readMachineID()
 
+var pid = os.Getpid()
+
 // readMachineId generates machine id and puts it into the machineId global
 // variable. If this function fails to get the hostname, it will cause
 // a runtime error.
@@ -115,7 +117,6 @@ func New() ID {
 	id[5] = machineID[1]
 	id[6] = machineID[2]
 	// Pid, 2 bytes, specs don't specify endianness, but we use big endian.
-	pid := os.Getpid()
 	id[7] = byte(pid >> 8)
 	id[8] = byte(pid)
 	// Increment, 3 bytes, big endian

--- a/id_test.go
+++ b/id_test.go
@@ -123,3 +123,9 @@ func TestIDJSONUnmarshalingError(t *testing.T) {
 	err = json.Unmarshal([]byte(`{"ID":"TYjhW2D0huQoQS3kdk"}`), &v)
 	assert.EqualError(t, err, "invalid ID")
 }
+
+func BenchmarkNew(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		New()
+	}
+}


### PR DESCRIPTION
Get the process id just once instead of every time we generate an ID. Without this change an id generation takes `159ns`, after this change this is just `27ns`.

I've also added an benchark to this pull request. So you can verify it yourself. Compared to many other id libraries, xid is crazy fast after this change.