### PR TITLE
Copy text when unmarshaling to avoid sync errors

### DIFF
--- a/id.go
+++ b/id.go
@@ -162,16 +162,13 @@ func (id *ID) UnmarshalText(text []byte) error {
 			return ErrInvalidID
 		}
 	}
-	b := make([]byte, decodedLen)
-	_, err := b32enc.Decode(b, append(text, '=', '=', '=', '='))
-	for i, c := range b {
-		id[i] = c
-		// The decoded len is larger than the actual len because of padding.
-		// Stop copying data when we reach raw len.
-		if i+1 == rawLen {
-			break
-		}
-	}
+	var (
+		bufe [trimLen + 4]byte
+		bufd [decodedLen]byte
+	)
+	copy(bufe[:], text)
+	_, err := b32enc.Decode(bufd[:], append(bufe[:trimLen], '=', '=', '=', '='))
+	copy(id[:], bufd[:])
 	return err
 }
 

--- a/id_test.go
+++ b/id_test.go
@@ -97,19 +97,20 @@ func TestFromStringInvalid(t *testing.T) {
 }
 
 type jsonType struct {
-	ID *ID
+	ID  *ID
+	Str string
 }
 
 func TestIDJSONMarshaling(t *testing.T) {
 	id := ID{0x4d, 0x88, 0xe1, 0x5b, 0x60, 0xf4, 0x86, 0xe4, 0x28, 0x41, 0x2d, 0xc9}
-	v := jsonType{ID: &id}
+	v := jsonType{ID: &id, Str: "test"}
 	data, err := json.Marshal(&v)
 	assert.NoError(t, err)
-	assert.Equal(t, `{"ID":"9m4e2mr0ui3e8a215n4g"}`, string(data))
+	assert.Equal(t, `{"ID":"9m4e2mr0ui3e8a215n4g","Str":"test"}`, string(data))
 }
 
 func TestIDJSONUnmarshaling(t *testing.T) {
-	data := []byte(`{"ID":"9m4e2mr0ui3e8a215n4g"}`)
+	data := []byte(`{"ID":"9m4e2mr0ui3e8a215n4g","Str":"test"}`)
 	v := jsonType{}
 	err := json.Unmarshal(data, &v)
 	assert.NoError(t, err)


### PR DESCRIPTION
text should not be altered as it can cause unmarshaling synchronization errors.