### PR TITLE
Add a Scala implementation to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ References:
 - https://en.wikipedia.org/wiki/Universally_unique_identifier
 - https://blog.twitter.com/2010/announcing-snowflake
 - Python port by [Graham Abbott](https://github.com/graham): https://github.com/graham/python_xid
+- Scala port by [Egor Kolotaev](https://github.com/kolotaev): https://github.com/kolotaev/ride
 
 ## Install
 


### PR DESCRIPTION
Hi,
I'd like to add a link to a Scala port of xid in case someone is interested in this library on the JVM side. Given that there already has been a question about that by @on99
Thanks.