### PR TITLE
add go.mod file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/komuw/xid
+module github.com/rs/xid

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/komuw/xid


### PR DESCRIPTION
add a go.mod file so as to prepare for vgo; https://github.com/golang/vgo

But the main reason I added this PR is so as to ask the maintainer to properly semver tag this repository. 
right now `github.com/rs/xid` has git tags like`v1.0` `v1.1` 
If you have `github.com/rs/xid` as a dependency on your app and you use vgo as dependency manager; it is generating a `go.mod` file like;
```bash
module github/komuw/myModule

require (
	github.com/rs/xid v0.0.0-20170604230408-02dd45c33376
	github.com/rs/zerolog v1.4.0
)
```
instead of picking xid tag v1.1 

So my proposal is that, this project should add a new semver tag like; v1.1.0
