### PR TITLE
Fix Quotation Around go.mod Module Name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/rs/xid
+module "github.com/rs/xid"


### PR DESCRIPTION
Missing quotes around the module name, which causes `vgo build` to panic.

```
vgo: parsing downloaded go.mod: go.mod:1:19: unexpected input character 'r'
```