### PR TITLE
Use raw byte representation for sql Value() and Scan()

### DIFF
--- a/id.go
+++ b/id.go
@@ -293,8 +293,7 @@ func (id ID) Value() (driver.Value, error) {
 	if id.IsNil() {
 		return nil, nil
 	}
-	b, err := id.MarshalText()
-	return string(b), err
+	return id[:], nil
 }
 
 // Scan implements the sql.Scanner interface.
@@ -303,7 +302,8 @@ func (id *ID) Scan(value interface{}) (err error) {
 	case string:
 		return id.UnmarshalText([]byte(val))
 	case []byte:
-		return id.UnmarshalText(val)
+		copy((*id)[:], val)
+		return nil
 	case nil:
 		*id = nilID
 		return nil

--- a/id_test.go
+++ b/id_test.go
@@ -176,8 +176,12 @@ func TestIDDriverValue(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if want := "9m4e2mr0ui3e8a215n4g"; got != want {
-		t.Errorf("Value() = %v, want %v", got, want)
+	if gotb, ok := got.([]byte); ok {
+		if !bytes.Equal(gotb, id[:]) {
+			t.Errorf("Value() = %v, want %v", gotb, id)
+		}
+	} else {
+		t.Errorf("Value() returned unexpected type: %T", got)
 	}
 }
 
@@ -205,7 +209,7 @@ func TestIDDriverScanError(t *testing.T) {
 
 func TestIDDriverScanByteFromDatabase(t *testing.T) {
 	got := ID{}
-	bs := []byte("9m4e2mr0ui3e8a215n4g")
+	bs := []byte{0x4d, 0x88, 0xe1, 0x5b, 0x60, 0xf4, 0x86, 0xe4, 0x28, 0x41, 0x2d, 0xc9}
 	err := got.Scan(bs)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR proposes an alternative marshaling format for database operations: rather than use the relatively inefficient 20-byte string, it is possible to support the more efficient 12-byte raw value. This is a better options for databases like Postgres that support arbitrary byte-string types.

Note that I don't intend this PR to be merged in as-is; given that a lot of people likely use the string-based behavior already, I think it would make more sense to somehow make this configurable. The initial commit here is more to demonstrate what it would look like to use raw bytes instead of strings.