### PR TITLE
[patch] improve performance

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/rs/xid
+
+go 1.12

--- a/id.go
+++ b/id.go
@@ -55,6 +55,7 @@ import (
 	"sort"
 	"sync/atomic"
 	"time"
+	"unsafe"
 )
 
 // Code inspired from mgo/bson ObjectId
@@ -177,7 +178,7 @@ func FromString(id string) (ID, error) {
 func (id ID) String() string {
 	text := make([]byte, encodedLen)
 	encode(text, id[:])
-	return string(text)
+	return *(*string)(unsafe.Pointer(&text))
 }
 
 // MarshalText implements encoding/text TextMarshaler interface
@@ -198,26 +199,29 @@ func (id ID) MarshalJSON() ([]byte, error) {
 
 // encode by unrolling the stdlib base32 algorithm + removing all safe checks
 func encode(dst, id []byte) {
-	dst[0] = encoding[id[0]>>3]
-	dst[1] = encoding[(id[1]>>6)&0x1F|(id[0]<<2)&0x1F]
-	dst[2] = encoding[(id[1]>>1)&0x1F]
-	dst[3] = encoding[(id[2]>>4)&0x1F|(id[1]<<4)&0x1F]
-	dst[4] = encoding[id[3]>>7|(id[2]<<1)&0x1F]
-	dst[5] = encoding[(id[3]>>2)&0x1F]
-	dst[6] = encoding[id[4]>>5|(id[3]<<3)&0x1F]
-	dst[7] = encoding[id[4]&0x1F]
-	dst[8] = encoding[id[5]>>3]
-	dst[9] = encoding[(id[6]>>6)&0x1F|(id[5]<<2)&0x1F]
-	dst[10] = encoding[(id[6]>>1)&0x1F]
-	dst[11] = encoding[(id[7]>>4)&0x1F|(id[6]<<4)&0x1F]
-	dst[12] = encoding[id[8]>>7|(id[7]<<1)&0x1F]
-	dst[13] = encoding[(id[8]>>2)&0x1F]
-	dst[14] = encoding[(id[9]>>5)|(id[8]<<3)&0x1F]
-	dst[15] = encoding[id[9]&0x1F]
-	dst[16] = encoding[id[10]>>3]
-	dst[17] = encoding[(id[11]>>6)&0x1F|(id[10]<<2)&0x1F]
-	dst[18] = encoding[(id[11]>>1)&0x1F]
+	_ = dst[19]
+	_ = id[11]
+
 	dst[19] = encoding[(id[11]<<4)&0x1F]
+	dst[18] = encoding[(id[11]>>1)&0x1F]
+	dst[17] = encoding[(id[11]>>6)&0x1F|(id[10]<<2)&0x1F]
+	dst[16] = encoding[id[10]>>3]
+	dst[15] = encoding[id[9]&0x1F]
+	dst[14] = encoding[(id[9]>>5)|(id[8]<<3)&0x1F]
+	dst[13] = encoding[(id[8]>>2)&0x1F]
+	dst[12] = encoding[id[8]>>7|(id[7]<<1)&0x1F]
+	dst[11] = encoding[(id[7]>>4)&0x1F|(id[6]<<4)&0x1F]
+	dst[10] = encoding[(id[6]>>1)&0x1F]
+	dst[9] = encoding[(id[6]>>6)&0x1F|(id[5]<<2)&0x1F]
+	dst[8] = encoding[id[5]>>3]
+	dst[7] = encoding[id[4]&0x1F]
+	dst[6] = encoding[id[4]>>5|(id[3]<<3)&0x1F]
+	dst[5] = encoding[(id[3]>>2)&0x1F]
+	dst[4] = encoding[id[3]>>7|(id[2]<<1)&0x1F]
+	dst[3] = encoding[(id[2]>>4)&0x1F|(id[1]<<4)&0x1F]
+	dst[2] = encoding[(id[1]>>1)&0x1F]
+	dst[1] = encoding[(id[1]>>6)&0x1F|(id[0]<<2)&0x1F]
+	dst[0] = encoding[id[0]>>3]
 }
 
 // UnmarshalText implements encoding/text TextUnmarshaler interface
@@ -246,18 +250,21 @@ func (id *ID) UnmarshalJSON(b []byte) error {
 
 // decode by unrolling the stdlib base32 algorithm + removing all safe checks
 func decode(id *ID, src []byte) {
-	id[0] = dec[src[0]]<<3 | dec[src[1]]>>2
-	id[1] = dec[src[1]]<<6 | dec[src[2]]<<1 | dec[src[3]]>>4
-	id[2] = dec[src[3]]<<4 | dec[src[4]]>>1
-	id[3] = dec[src[4]]<<7 | dec[src[5]]<<2 | dec[src[6]]>>3
-	id[4] = dec[src[6]]<<5 | dec[src[7]]
-	id[5] = dec[src[8]]<<3 | dec[src[9]]>>2
-	id[6] = dec[src[9]]<<6 | dec[src[10]]<<1 | dec[src[11]]>>4
-	id[7] = dec[src[11]]<<4 | dec[src[12]]>>1
-	id[8] = dec[src[12]]<<7 | dec[src[13]]<<2 | dec[src[14]]>>3
-	id[9] = dec[src[14]]<<5 | dec[src[15]]
-	id[10] = dec[src[16]]<<3 | dec[src[17]]>>2
+	_ = src[19]
+	_ = id[11]
+
 	id[11] = dec[src[17]]<<6 | dec[src[18]]<<1 | dec[src[19]]>>4
+	id[10] = dec[src[16]]<<3 | dec[src[17]]>>2
+	id[9] = dec[src[14]]<<5 | dec[src[15]]
+	id[8] = dec[src[12]]<<7 | dec[src[13]]<<2 | dec[src[14]]>>3
+	id[7] = dec[src[11]]<<4 | dec[src[12]]>>1
+	id[6] = dec[src[9]]<<6 | dec[src[10]]<<1 | dec[src[11]]>>4
+	id[5] = dec[src[8]]<<3 | dec[src[9]]>>2
+	id[4] = dec[src[6]]<<5 | dec[src[7]]
+	id[3] = dec[src[4]]<<7 | dec[src[5]]<<2 | dec[src[6]]>>3
+	id[2] = dec[src[3]]<<4 | dec[src[4]]>>1
+	id[1] = dec[src[1]]<<6 | dec[src[2]]<<1 | dec[src[3]]>>4
+	id[0] = dec[src[0]]<<3 | dec[src[1]]>>2
 }
 
 // Time returns the timestamp part of the id.


### PR DESCRIPTION
Hi, I patched 2 fixes for performance improvement.

1. It is possible to skip the subsequent boundary value check by accessing from the end of the slice, so I changed it.  ( https://go101.org/article/bounds-check-elimination.html#slice-comparison )
2. zero copy casting like strings.Builder. ( https://golang.org/src/strings/builder.go?s=1416:1457#L36 )

Signed-off-by: kpango <i.can.feel.gravity@gmail.com>