### PR TITLE
Avoid unnecessary alloc in MarshalJSON

### DIFF
--- a/id.go
+++ b/id.go
@@ -193,8 +193,10 @@ func (id ID) MarshalJSON() ([]byte, error) {
 	if id.IsNil() {
 		return []byte("null"), nil
 	}
-	text, err := id.MarshalText()
-	return []byte(`"` + string(text) + `"`), err
+	text := make([]byte, encodedLen+2)
+	encode(text[1:encodedLen+1], id[:])
+	text[0], text[encodedLen+1] = '"', '"'
+	return text, nil
 }
 
 // encode by unrolling the stdlib base32 algorithm + removing all safe checks


### PR DESCRIPTION
As per title, 1 alloc within MarshalJSON can be avoided at the cost of a tiny bit of duplication.

    benchmark                  old ns/op     new ns/op     delta
    BenchmarkMarshalJSON-8     45.1          32.0          -29.05%

    benchmark                  old allocs    new allocs    delta
    BenchmarkMarshalJSON-8     2             1             -50.00%

    benchmark                  old bytes     new bytes     delta
    BenchmarkMarshalJSON-8     64            32            -50.00%
