### PR TITLE
add Encode method for memory sensitive cases

### DIFF
--- a/id.go
+++ b/id.go
@@ -181,6 +181,12 @@ func (id ID) String() string {
 	return *(*string)(unsafe.Pointer(&text))
 }
 
+// Encode encodes the id using base32 encoding, writing 20 bytes to dst and return it.
+func (id ID) Encode(dst []byte) []byte {
+	encode(dst, id[:])
+	return dst
+}
+
 // MarshalText implements encoding/text TextMarshaler interface
 func (id ID) MarshalText() ([]byte, error) {
 	text := make([]byte, encodedLen)

--- a/id_test.go
+++ b/id_test.go
@@ -105,6 +105,14 @@ func TestIDString(t *testing.T) {
 	}
 }
 
+func TestIDEncode(t *testing.T) {
+	id := ID{0x4d, 0x88, 0xe1, 0x5b, 0x60, 0xf4, 0x86, 0xe4, 0x28, 0x41, 0x2d, 0xc9}
+	text := make([]byte, encodedLen)
+	if got, want := string(id.Encode(text)), "9m4e2mr0ui3e8a215n4g"; got != want {
+		t.Errorf("Encode() = %v, want %v", got, want)
+	}
+}
+
 func TestFromString(t *testing.T) {
 	got, err := FromString("9m4e2mr0ui3e8a215n4g")
 	if err != nil {


### PR DESCRIPTION
xid is wonderful for tracing, it would be nice to add a `Encode` method, enabling us to write zero allocation servers. Thanks.

Signed-off-by: phuslu <phus.lu@gmail.com>