### PR TITLE
Try /etc/machine-id for linux first

### DIFF
--- a/hostid_linux.go
+++ b/hostid_linux.go
@@ -5,6 +5,9 @@ package xid
 import "io/ioutil"
 
 func readPlatformMachineID() (string, error) {
-	b, err := ioutil.ReadFile("/sys/class/dmi/id/product_uuid")
+	b, err := ioutil.ReadFile("/etc/machine-id")
+	if err != nil || len(b) == 0 {
+		b, err = ioutil.ReadFile("/sys/class/dmi/id/product_uuid")
+	}
 	return string(b), err
 }


### PR DESCRIPTION
read "/sys/class/dmi/id/product_uuid" requires root permission, so we could try "/etc/machine-id" at first.

[1] https://man7.org/linux/man-pages/man5/machine-id.5.html