### PR TITLE
Fix panic on unmarshalling JSON

### DIFF
--- a/id.go
+++ b/id.go
@@ -253,6 +253,10 @@ func (id *ID) UnmarshalJSON(b []byte) error {
 		*id = nilID
 		return nil
 	}
+	// Check the slice length to prevent panic on passing it to UnmarshalText()
+	if len(b) < 2 {
+		return ErrInvalidID
+	}
 	return id.UnmarshalText(b[1 : len(b)-1])
 }
 

--- a/id_test.go
+++ b/id_test.go
@@ -176,6 +176,10 @@ func TestIDJSONUnmarshalingError(t *testing.T) {
 	if err != ErrInvalidID {
 		t.Errorf("json.Unmarshal() err=%v, want %v", err, ErrInvalidID)
 	}
+	err = json.Unmarshal([]byte(`{"ID":1}`), &v)
+	if err != ErrInvalidID {
+		t.Errorf("json.Unmarshal() err=%v, want %v", err, ErrInvalidID)
+	}
 }
 
 func TestIDDriverValue(t *testing.T) {


### PR DESCRIPTION
Unmarshalling of one-digit integers causes panic.
```
panic: runtime error: slice bounds out of range [1:0]
```