### PR TITLE
Use dbus/machine-id instead of id/product_uuid

### DIFF
--- a/hostid_linux.go
+++ b/hostid_linux.go
@@ -7,7 +7,7 @@ import "io/ioutil"
 func readPlatformMachineID() (string, error) {
 	b, err := ioutil.ReadFile("/etc/machine-id")
 	if err != nil || len(b) == 0 {
-		b, err = ioutil.ReadFile("/sys/class/dmi/id/product_uuid")
+		b, err = ioutil.ReadFile("/var/lib/dbus/machine-id")
 	}
 	return string(b), err
 }


### PR DESCRIPTION
For the reasons explained [here](https://0pointer.de/blog/projects/ids.html), using `/sys/class/dmi/id/product_uuid` is not such a clever idea.