### PR TITLE
Remove go cache in github action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,6 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-          cache: true
       - run: go test -race -failfast ./...
   golangci-lint:
     name: golangci-lint
@@ -29,7 +28,6 @@ jobs:
         with:
           go-version: "1.18"
           check-latest: true
-          cache: true
       - uses: golangci/golangci-lint-action@v3
         with:
           version: latest


### PR DESCRIPTION
Currently golang github action failed.
Because I enable cache, but there is no `go.sum` to cache so this MR will delete it.

https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs