### PR TITLE
clarified used encoding --> base32hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Package xid is a globally unique id generator library, ready to safely be used directly in your server code.
 
-Xid uses the Mongo Object ID algorithm to generate globally unique ids with a different serialization (base64) to make it shorter when transported as a string:
+Xid uses the Mongo Object ID algorithm to generate globally unique ids with a different serialization ([base32hex](https://datatracker.ietf.org/doc/html/rfc4648#page-10)) to make it shorter when transported as a string:
 https://docs.mongodb.org/manual/reference/object-id/
 
 - 4-byte value representing the seconds since the Unix epoch,
@@ -13,7 +13,7 @@ https://docs.mongodb.org/manual/reference/object-id/
 - 3-byte counter, starting with a random value.
 
 The binary representation of the id is compatible with Mongo 12 bytes Object IDs.
-The string representation is using base32 hex (w/o padding) for better space efficiency
+The string representation is using [base32hex](https://datatracker.ietf.org/doc/html/rfc4648#page-10) (w/o padding) for better space efficiency
 when stored in that form (20 bytes). The hex variant of base32 is used to retain the
 sortable property of the id.
 


### PR DESCRIPTION
I believe there is a mistake in the second paragraph (when base64 is mentioned). I fixed it and provided more context around base32hex