### PR TITLE
Remove calls to deprecated `ioutil` package.

### DIFF
--- a/hostid_linux.go
+++ b/hostid_linux.go
@@ -1,4 +1,3 @@
-//go:build linux
 // +build linux
 
 package xid

--- a/hostid_linux.go
+++ b/hostid_linux.go
@@ -1,13 +1,14 @@
+//go:build linux
 // +build linux
 
 package xid
 
-import "io/ioutil"
+import "os"
 
 func readPlatformMachineID() (string, error) {
-	b, err := ioutil.ReadFile("/etc/machine-id")
+	b, err := os.ReadFile("/etc/machine-id")
 	if err != nil || len(b) == 0 {
-		b, err = ioutil.ReadFile("/sys/class/dmi/id/product_uuid")
+		b, err = os.ReadFile("/sys/class/dmi/id/product_uuid")
 	}
 	return string(b), err
 }

--- a/id.go
+++ b/id.go
@@ -43,13 +43,12 @@ package xid
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"crypto/rand"
+	"crypto/sha256"
 	"database/sql/driver"
 	"encoding/binary"
 	"fmt"
 	"hash/crc32"
-	"io/ioutil"
 	"os"
 	"sort"
 	"sync/atomic"
@@ -98,7 +97,7 @@ func init() {
 	// If /proc/self/cpuset exists and is not /, we can assume that we are in a
 	// form of container and use the content of cpuset xor-ed with the PID in
 	// order get a reasonable machine global unique PID.
-	b, err := ioutil.ReadFile("/proc/self/cpuset")
+	b, err := os.ReadFile("/proc/self/cpuset")
 	if err == nil && len(b) > 1 {
 		pid ^= int(crc32.ChecksumIEEE(b))
 	}


### PR DESCRIPTION
The `ioutil` package was deprecated with the [release of Go 1.16](https://go.dev/doc/go1.16#ioutil).

I've removed calls to the old package and replaced them with their counterparts. There shouldn't be any change in behaviour, as I think the calls were internally mapped already.

This does remove some annoying LSP warnings though.