### PR TITLE
Allow MachineID to be set

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ generator servers. xid stands in between with 12 bytes (96 bits) and a more comp
 URL-safe string representation (20 chars). No configuration or central generator server
 is required so it can be used directly in server's code.
 
-| Name        | Binary Size | String Size    | Features
-|-------------|-------------|----------------|----------------
-| [UUID]      | 16 bytes    | 36 chars       | configuration free, not sortable
-| [shortuuid] | 16 bytes    | 22 chars       | configuration free, not sortable
-| [Snowflake] | 8 bytes     | up to 20 chars | needs machine/DC configuration, needs central server, sortable
-| [MongoID]   | 12 bytes    | 24 chars       | configuration free, sortable
-| xid         | 12 bytes    | 20 chars       | configuration free, sortable
+| Name        | Binary Size | String Size    | Features                                                       |
+| ----------- | ----------- | -------------- | -------------------------------------------------------------- |
+| [UUID]      | 16 bytes    | 36 chars       | configuration free, not sortable                               |
+| [shortuuid] | 16 bytes    | 22 chars       | configuration free, not sortable                               |
+| [Snowflake] | 8 bytes     | up to 20 chars | needs machine/DC configuration, needs central server, sortable |
+| [MongoID]   | 12 bytes    | 24 chars       | configuration free, sortable                                   |
+| xid         | 12 bytes    | 20 chars       | configuration free, sortable                                   |
 
 [UUID]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 [shortuuid]: https://github.com/stochastic-technologies/shortuuid
@@ -46,7 +46,7 @@ Features:
 
 - Size: 12 bytes (96 bits), smaller than UUID, larger than snowflake
 - Base32 hex encoded by default (20 chars when transported as printable string, still sortable)
-- Non configured, you don't need set a unique machine and/or data center id
+- Non configured, you don't need set a unique machine and/or data center id (configurable if needed)
 - K-ordered
 - Embedded time with 1 second precision
 - Unicity guaranteed for 16,777,216 (24 bits) unique ids per second and per host/process
@@ -58,6 +58,7 @@ Best used with [zerolog](https://github.com/rs/zerolog)'s
 Notes:
 
 - Xid is dependent on the system time, a monotonic counter and so is not cryptographically secure. If unpredictability of IDs is important, you should not use Xids. It is worth noting that most other UUID-like implementations are also not cryptographically secure. You should use libraries that rely on cryptographically secure sources (like /dev/urandom on unix, crypto/rand in golang), if you want a truly random ID generator.
+- MachineID can be set by the environmental variable `XID_MACHINE_ID` to allow fine tune control over the generation.
 
 References:
 

--- a/id.go
+++ b/id.go
@@ -125,6 +125,15 @@ func readMachineID() []byte {
 	return id
 }
 
+// SetMachineID allows for the Machine ID to be set by a byte array with 3
+// bytes. It is not safe for concurrent use and should be used prior to
+// generating IDs. MachineID is traditionally automatically set and generally
+// does not need to be overwritten, except in cases where fine tune control over
+// instances generating IDs needs to be controlled.
+func SetMachineID(id [3]byte) {
+	machineID = id[:]
+}
+
 // randInt generates a random uint32
 func randInt() uint32 {
 	b := make([]byte, 3)

--- a/id.go
+++ b/id.go
@@ -51,6 +51,7 @@ import (
 	"hash/crc32"
 	"os"
 	"sort"
+	"strconv"
 	"sync/atomic"
 	"time"
 )
@@ -107,6 +108,11 @@ func init() {
 // value, or else the machine's hostname, or else a randomly-generated number.
 // It panics if all of these methods fail.
 func readMachineID() []byte {
+	// Allow env overrides for the machine id
+	if id := readMachineIDFromEnv(); len(id) == 3 {
+		return id
+	}
+
 	id := make([]byte, 3)
 	hid, err := readPlatformMachineID()
 	if err != nil || len(hid) == 0 {
@@ -125,13 +131,23 @@ func readMachineID() []byte {
 	return id
 }
 
-// SetMachineID allows for the Machine ID to be set by a byte array with 3
-// bytes. It is not safe for concurrent use and should be used prior to
-// generating IDs. MachineID is traditionally automatically set and generally
-// does not need to be overwritten, except in cases where fine tune control over
-// instances generating IDs needs to be controlled.
-func SetMachineID(id [3]byte) {
-	machineID = id[:]
+func readMachineIDFromEnv() []byte {
+	envMachineID := os.Getenv("XID_MACHINE_ID")
+	if envMachineID == "" {
+		return nil
+	}
+
+	num, err := strconv.Atoi(envMachineID)
+	if err != nil {
+		panic("XID_MACHINE_ID value is set to not a number")
+	}
+
+	if num < 0 || num > 0xFFFFFF {
+		panic("XID_MACHINE_ID out of range for 3 bytes")
+	}
+
+	// Encode the number into big endian.
+	return []byte{byte(num >> 16), byte(num >> 8), byte(num)}
 }
 
 // randInt generates a random uint32


### PR DESCRIPTION
To go along with my suggestion in https://github.com/rs/xid/issues/112, this simple addition would solve some edge cases I've been seeing, and wouldn't change default behavior for generating ids. 